### PR TITLE
volume-manifest-tool-28 W20869 doesn't create manifest correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ When you install `volume-manifest-tool` two entry points are defined in `/usr/lo
 ## Building a distribution
 
 Be sure to check PyPI for current release, and update accoringly. Use [PEP440](https://www.python.org/dev/peps/pep-0440/#post-releases) for naming releases.
+
+### Prerequisites
+- `pip3 install wheel`
+- `pip3 install twine`
+
 ```bash
 python3 setup.py bdist_wheel
 twine upload dist/<thing you built

--- a/service/README.md
+++ b/service/README.md
@@ -2,7 +2,8 @@
 * copy sattva:~dev/volume-manifest-tool/etc up to Git
 * document need credentials in /.aws (running as root)
 * document need manifest.sh installed from etc.
-* make sure all service/uer/local/bin files are exec# service
+* make sure all service/usr/local/bin files are executable by user `service`
+
 Define a service which launches on startup to run the volume manifest tool
 This service is built for a specific AWS AMI running Ubuntu (problems with Python 3.7 on ), but has also been tested on Debian 9 and 10 (stretch).
 ## Operating environment

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ from setuptools import setup, find_packages
 
 console_scripts = ['manifestforwork = v_m_t.manifestforwork:manifestShell',
                    'manifestFromS3 = v_m_t.manifestforwork:manifestFromS3']
-setup(name='volume-manifest-tool', version='1.0.1b1', packages=find_packages(),
+setup(name='volume-manifest-tool', version='1.0.1b2', packages=find_packages(),
       url='https://github.com/buda-base/volume-manifest-tool/', license='', author='jimk', author_email='jimk@tbrc.org',
       description='Creates manifests for syncd works.', entry_points={'console_scripts': console_scripts},
       install_requires=['boto3', 'requests', 'lxml', 'pillow', 's3transfer', 'botocore'], python_requires='>=3.6',
       classifiers=["Programming Language :: Python :: 3", "License :: OSI Approved :: MIT License",
                    "Operating System :: MacOS :: MacOS X", "Operating System :: OS Independent",
-                   "Development Status :: 4 - Beta"])
+                   "Development Status :: 5 - Released"])

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ from setuptools import setup, find_packages
 
 console_scripts = ['manifestforwork = v_m_t.manifestforwork:manifestShell',
                    'manifestFromS3 = v_m_t.manifestforwork:manifestFromS3']
-setup(name='volume-manifest-tool', version='1.0.1b2', packages=find_packages(),
+setup(name='volume-manifest-tool', version='1.0.2', packages=find_packages(),
       url='https://github.com/buda-base/volume-manifest-tool/', license='', author='jimk', author_email='jimk@tbrc.org',
       description='Creates manifests for syncd works.', entry_points={'console_scripts': console_scripts},
       install_requires=['boto3', 'requests', 'lxml', 'pillow', 's3transfer', 'botocore'], python_requires='>=3.6',
       classifiers=["Programming Language :: Python :: 3", "License :: OSI Approved :: MIT License",
                    "Operating System :: MacOS :: MacOS X", "Operating System :: OS Independent",
-                   "Development Status :: 5 - Released"])
+                   "Development Status :: 5 - Production/Stable"])

--- a/v_m_t/VolumeInfoBase.py
+++ b/v_m_t/VolumeInfoBase.py
@@ -70,17 +70,20 @@ class VolumeInfoBase(metaclass=abc.ABCMeta):
         json_body: {} = {}
 
         try:
-            obj = s3.get_object(Bucket=self.s3_image_bucket.name, Key=bom_path)
+            obj = s3.get_object(Bucket=self.s3_image_bucket.name, Key='NO' + bom_path)
             #
             # Python 3 read() returns bytes which need decode
             json_body = json.loads(obj['Body'].read().decode('utf - 8'))
 
-            self.logger.info("read bom from s3 object size %d json body size %d", len(obj), len(json_body))
+            self.logger.info("read bom from s3 object size %d json body size %d path %s",
+                             len(obj), len(json_body), bom_path)
         except ClientError as ex:
+            errstr: str = f"ClientError Exception {ex.response['Error']['Code']} Message f{ex.response['Error']['Message']} on object {ex.response['Error']['Key']} for our BOMPath  {bom_path}  from bucket f{self.s3_image_bucket.name}"
+
             if ex.response['Error']['Code'] == 'NoSuchKey':
-                self.logger.warning(
-                    "Exception NoSuchKey trying to retrieve BOM f{bom_path}  from bucket f{self.s3_image_bucket.name}")
+                self.logger.warning(str)
             else:
+                self.logger.error(str)
                 raise
 
         return [x[VMT_BUDABOM_KEY] for x in json_body]

--- a/v_m_t/manifestforwork.py
+++ b/v_m_t/manifestforwork.py
@@ -14,6 +14,7 @@ import boto3
 import botocore
 from PIL import Image
 from boto.s3.bucket import Bucket
+from botocore.exceptions import ClientError
 
 from .AOLogger import AOLogger
 from .S3WorkFileManager import S3WorkFileManager
@@ -266,9 +267,14 @@ def uploadManifest(bucket, s3folderPrefix, manifestObject):
     manifest_gzip = gzip_str(manifest_str)
 
     key = s3folderPrefix + 'dimensions.json'
-    shell_logger.info("writing " + key)
-    bucket.put_object(Key=key, Body=manifest_gzip,
-                      Metadata={'ContentType': 'application/json', 'ContentEncoding': 'gzip'}, Bucket=S3_DEST_BUCKET)
+    shell_logger.debug("writing " + key)
+    try:
+        bucket.put_object(Key=key, Body=manifest_gzip,
+                          Metadata={'ContentType': 'application/json', 'ContentEncoding': 'gzip'},
+                          Bucket=S3_DEST_BUCKET)
+        shell_logger.info("wrote " + key)
+    except ClientError:
+        shell_logger.warn(f"Couldn't write json {key}")
 
 
 def manifestExists(client, s3folderPrefix):

--- a/v_m_t/manifestforwork.py
+++ b/v_m_t/manifestforwork.py
@@ -231,7 +231,7 @@ def manifestForVolume(client, workRID, vi, csvwriter):
 
     s3_folder_prefix: str = get_s3_folder_prefix(workRID, vi.imageGroupID)
     if manifestExists(client, s3_folder_prefix):
-        shell_logger.info("manifest exists: " + workRID + "-" + vi.imageGroupID)  # return
+        shell_logger.info(f"manifest exists: {workRID}-{vi.imageGroupID} path :{s3_folder_prefix}:")
     manifest = generateManifest(client, s3_folder_prefix, vi.imageList, csvwriter, workRID, vi.imageGroupID)
     uploadManifest(client, s3_folder_prefix, manifest)
 


### PR DESCRIPTION
Changed program logic to swallow exception when BOM can't be found on S3. This will invoke the fallback strategy of listing all the objects in the folder and generating the manifest from that.