### PR TITLE
Make I+4 fixup available to all code paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 console_scripts = ['manifestforwork = v_m_b.manifestBuilder:manifestShell',
                    'manifestFromS3 = v_m_b.manifestBuilder:manifestFromS3']
 
-setup(version='1.1.2',
+setup(version='1.1.3',
       name='bdrc-volume-manifest-builder',
       packages=find_packages(),
       url='https://github.com/buda-base/volume-manifest-builder/', license='', author='jimk',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 console_scripts = ['manifestforwork = v_m_b.manifestBuilder:manifestShell',
                    'manifestFromS3 = v_m_b.manifestBuilder:manifestFromS3']
 
-setup(version='1.1.1',
+setup(version='1.1.2',
       name='bdrc-volume-manifest-builder',
       packages=find_packages(),
       url='https://github.com/buda-base/volume-manifest-builder/', license='', author='jimk',

--- a/v_m_b/ImageRepository/FSImageRepository.py
+++ b/v_m_b/ImageRepository/FSImageRepository.py
@@ -113,17 +113,19 @@ class FSImageRepository(ImageRepositoryBase):
         w_path = self.fullPath(str(Path(self._container, work_rid_path)))
         return os.path.dirname(w_path), os.path.basename(w_path)
 
-    def resolveImageGroup(self, work_Rid: str, image_group_name: str) -> Path:
+    def resolveImageGroup(self, work_Rid: str, image_group_folder_name: str) -> Path:
         """
         Fully qualifies a RID and a Path
         :param work_Rid:
-        :param image_group_name:
-        :return: fully qualified path to image group
+        :param image_group_name: Image group folder name
+        :return: fully qualified path to image group. The I{d}{4} issue is resolved in VolInfo
         """
         _work: str
         _dir, _work = self.resolveWork(work_Rid)
+       # shouldn't need this any more, moved into Volinfos
+       # image_group_folder_name: str = self.getImageGroup(image_group_name)
         pre_path = Path(_dir, _work, self._image_folder_name)
-        v1path = Path(pre_path, f"{_work}-{image_group_name}")
+        v1path = Path(pre_path, f"{_work}-{image_group_folder_name}")
 
         # all image groups must exist
         if not os.path.exists(v1path):

--- a/v_m_b/ImageRepository/ImageRepositoryBase.py
+++ b/v_m_b/ImageRepository/ImageRepositoryBase.py
@@ -58,27 +58,12 @@ class ImageRepositoryBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def getPathfromLocators(self, work_Rid: str, image_group_id: str):
+    def getPathfromLocators(self, work_Rid: str, image_group_folder_name: str):
         """
         :param work_Rid: Work resource id
-        :param image_group_id: image group - gets transformed
+        :param image_group_folder_name: image group - gets transformed
         :returns:  the s3 prefix (~folder) in which the volume will be present.
         """
-
-    @staticmethod
-    def getImageGroup(image_group_id: str) -> str:
-        """
-        :param image_group_id:
-        :type image_group_id: str
-        Some old image groups in eXist are encoded Innn, but their real name on disk is
-        RID-nnnn. this detects their cases
-        """
-        pre, rest = image_group_id[0], image_group_id[1:]
-        if pre == 'I' and rest.isdigit() and len(rest) == 4:
-            suffix = rest
-        else:
-            suffix = image_group_id
-        return suffix
 
     @abstractmethod
     def resolveWork(self, work_rid_path: str) -> Tuple[str, str]:

--- a/v_m_b/ImageRepository/S3ImageRepository.py
+++ b/v_m_b/ImageRepository/S3ImageRepository.py
@@ -176,10 +176,10 @@ class S3ImageRepository(ImageRepositoryBase):
         except ClientError:
             self.repo_log.warn(f"Couldn't write json {key}")
 
-    def getPathfromLocators(self, work_Rid: str, image_group_id: str) -> str:
+    def getPathfromLocators(self, work_Rid: str, image_group_folder_name: str) -> str:
         """
         :param work_Rid: Work resource id
-        :param image_group_id: image group - gets transformed
+        :param image_group_folder_name: image group - gets transformed
         :returns:  the s3 prefix (~folder) in which the volume will be present.
 
         inpire from https://github.com/buda-base/buda-iiif-presentation/blob/master/src/main/java/
@@ -198,8 +198,8 @@ class S3ImageRepository(ImageRepositoryBase):
         md5 = hashlib.md5(str.encode(work_Rid))
         two = md5.hexdigest()[:2]
 
-        suffix = self.getImageGroup(image_group_id)
-        return f'Works/{two}/{work_Rid}/images/{work_Rid}-{suffix}/'
+        # Moved to VolInfossuffix = self.getImageGroup(image_group_folder_name)
+        return f'Works/{two}/{work_Rid}/images/{work_Rid}-{image_group_folder_name}/'
 
     def resolveWork(self, work_rid_path: str) -> Tuple[str, str]:
         """

--- a/v_m_b/VolumeInfo/VolumeInfoBase.py
+++ b/v_m_b/VolumeInfo/VolumeInfoBase.py
@@ -51,7 +51,6 @@ class VolumeInfoBase(metaclass=abc.ABCMeta):
             suffix = rest
         else:
             suffix = image_group_id
-        print(f"Input {image_group_id}")
         return suffix
 
     def getImageNames(self, work_rid: str, image_group: str, bom_name: str) -> []:

--- a/v_m_b/VolumeInfo/VolumeInfoBase.py
+++ b/v_m_b/VolumeInfo/VolumeInfoBase.py
@@ -36,6 +36,24 @@ class VolumeInfoBase(metaclass=abc.ABCMeta):
         """
         pass
 
+    @staticmethod
+    def getImageGroup(image_group_id: str) -> str:
+        """
+        :param image_group_id:
+        :type image_group_id: str
+        Some old image groups in eXist are encoded Innn, but their real name on disk is
+        RID-nnnn. this detects their cases, and returns the disk folder they actually
+        exist in. This is a stupid gross hack, we should either fix the archive repository, or have the
+        BUDA and/or eXist APIs adjust for this.
+        """
+        pre, rest = image_group_id[0], image_group_id[1:]
+        if pre == 'I' and rest.isdigit() and len(rest) == 4:
+            suffix = rest
+        else:
+            suffix = image_group_id
+        print(f"Input {image_group_id}")
+        return suffix
+
     def getImageNames(self, work_rid: str, image_group: str, bom_name: str) -> []:
         """
         get names of the image files (actually, all the files in an image group, regardless

--- a/v_m_b/VolumeInfo/VolumeInfoBuda.py
+++ b/v_m_b/VolumeInfo/VolumeInfoBuda.py
@@ -67,6 +67,7 @@ class VolumeInfoBUDA(VolumeInfoBase):
 
         _dir, _work = self._repo.resolveWork(work_rid)
 
+        # TODO: If we ever get this working again, good to document the output format
         req = f'http://purl.bdrc.io/query/table/Work_ImgList?R_RES=bdr:{_work}' \
               '&format=csv&profile=simple&pageSize=500'
         try:
@@ -75,6 +76,10 @@ class VolumeInfoBUDA(VolumeInfoBase):
                 info = _info.decode('utf8').strip()
                 lines = info.split('\n')[1:]
                 for line in lines:  # info.split('\n')[1:]:
+                    # appears each line contains:
+                    # _  an ignored variable
+                    #  l an encoded list of images
+                    #  g the image group
                     _, l, g = line.replace('"', '').split(',')
                     #
                     # jimk: mod: redefine volInfo to expand list here, rather than just before processing.

--- a/v_m_b/VolumeInfo/VolumeInfoeXist.py
+++ b/v_m_b/VolumeInfo/VolumeInfoeXist.py
@@ -71,7 +71,8 @@ class VolumeInfoeXist(VolumeInfoBase):
         """
         vi = []
         for ig in image_groups:
-            vol_infos = self.getImageNames(work_rid, ig, VMT_BUDABOM)
-            vi.append(VolInfo(vol_infos, ig))
+            ig_folder_name: str = self.getImageGroup(ig)
+            vol_infos = self.getImageNames(work_rid, ig_folder_name, VMT_BUDABOM)
+            vi.append(VolInfo(vol_infos, ig_folder_name))
 
         return vi

--- a/v_m_b/manifestBuilder.py
+++ b/v_m_b/manifestBuilder.py
@@ -160,5 +160,5 @@ def upload(work_Rid: str, image_group_name: str, manifest_object: object):
 
 
 if __name__ == '__main__':
-    # manifestShell()
-    manifestFromS3()
+    manifestShell()
+    # manifestFromS3()


### PR DESCRIPTION
Fixes #43
#43 was caused because the hack fixup for the "I+4" archives was only implemented for S3 type v-m-b runs, not for file system runs. 
The fix up code was moved into the `VolumeInfoBase` class (which is used early in the process, to derive the image groups and file lists, so that the fixup is transparent to the rest of the program.

The code in this pull request was tested in the context of `bdrcSync.sh` for the `fs` (file system) variant. For the `s3` variant, code was run standalone. 

The code was run and the resulting `dimensions.json` was compared to an existing one for identity.