### PR TITLE
Update AWS Python dependencies

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -29,7 +29,7 @@
     <option name="Skip Tests" value="false" />
     <pom-list />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7 (volume-manifest-builder)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (volume-manifest-builder)" project-jdk-type="Python SDK" />
   <component name="TaskProjectConfiguration">
     <server type="GitHub" url="https://github.com" />
   </component>

--- a/.idea/volume-manifest-tool.iml
+++ b/.idea/volume-manifest-tool.iml
@@ -8,7 +8,7 @@
       <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.7 (volume-manifest-builder)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.9 (volume-manifest-builder)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-boto3~=1.14.59
-Pillow~=7.2.0
-botocore~=1.17.59
-s3transfer~=0.3.3
-setuptools~=50.3.0
-boto~=2.49.0
-aiofiles~=0.5.0
+boto3
+Pillow
+botocore
+s3transfer
+setuptools
+boto
+aiofiles
 lxml
 requests

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ from os import path
 from setuptools import setup, find_packages
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+with open(path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 console_scripts = ['manifestforwork = v_m_b.manifestBuilder:manifestShell',
                    'manifestFromS3 = v_m_b.manifestBuilder:manifestFromS3']
 
-setup(version='1.1.5',
+setup(version='1.1.6',
       name='bdrc-volume-manifest-builder',
       packages=find_packages(),
       url='https://github.com/buda-base/volume-manifest-builder/', license='', author='jimk',


### PR DESCRIPTION
Fixes #49 

We haven't updated the Python pip `awscli` in some time. When we did (because of a new OS on bodhi), the pre-existing components that aws cli broke when we installed volume-manifest-builder (maybe because we installed v-m-b first). So this is a rebuild with just the requirements.txt removing version numbers.

We developers will just have to be more proactive about updating our dev sandboxes `venvs`