### PR TITLE
Create a format descriptor in dimensions.json

### DIFF
--- a/.idea/runConfigurations/manifestBuilder.xml
+++ b/.idea/runConfigurations/manifestBuilder.xml
@@ -13,7 +13,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/v_m_b/manifestBuilder.py" />
-    <option name="PARAMETERS" value="-l . -d debug -w ./W8LS68211 fs -c ./Archive" />
+    <option name="PARAMETERS" value="-l . -d debug -w ./W19801 fs -c ./vmb52" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/test/image_type_matching.py
+++ b/test/image_type_matching.py
@@ -1,0 +1,30 @@
+import unittest
+
+from v_m_b.image.generateManifest import is_BUDA_Matching_file_ext
+
+tests:[] = [
+    ['asdfgdfg.notther', 'NOT', False],
+    ['asdfgdfg.jpg', 'NOT', False],
+    ['asdfgdfg.TIF', 'not', False],
+    ['asdfgdfg.jpG', 'TIF', False],
+    ['asdfgdfg.JpG', 'tiff', False],
+    ['asdfgdfg.TIF', 'TIFF', True],
+    ['asdfgdfg.TiFF', 'TIFF', True],
+    ['asdfgdfg.Tif', 'JPEG', False],
+    ['asdfgdfg.JPEG', 'JPEG', True],
+    ['asdfgdfg.jpeG', 'JPEG', True],
+    ['asdfgdfg.jpG', 'JPEG', True],
+    ['asdfgdfg.JPG', 'JPEG', True],
+    ['', None, False],
+    [None, '', False],
+    [None, None, False]
+]
+
+
+class MyTestCase(unittest.TestCase):
+    def test_BUDA_Image_matching(self):
+        [self.assertEqual(is_BUDA_Matching_file_ext(x[0], x[1]), x[2], f"{x[0]} {x[1]}") for x in tests]  # add assertion here
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v_m_b/image/generateManifest.py
+++ b/v_m_b/image/generateManifest.py
@@ -88,6 +88,8 @@ def fillDataWithBlobImage(blob: io.BytesIO, data: dict):
     im = Image.open(blob)
     data["width"] = im.width
     data["height"] = im.height
+    # jimk volume_manifest_builder #52
+    data["format"] = im.format
     if 'dpi' in im.info.keys():
         # debian PIL casts these to floats, and debian JSON can't dump them to string
         data["dpi"] = [int(x) for x in im.info['dpi']]


### PR DESCRIPTION
Fixes #52 byt adding a descriptor named "format" to each node. The values of format are the ones found in the `PIL.features.pilinfo(suppoprted_formats=True)` command:

....
--------------------------------------------------------------------
BLP
Extensions: .blp
Features: open
--------------------------------------------------------------------
BMP image/bmp
Extensions: .bmp
Features: open, save
--------------------------------------------------------------------
BUFR
Extensions: .bufr
Features: open, save
--------------------------------------------------------------------
CUR
Extensions: .cur
Features: open
--------------------------------------------------------------------
DCX
Extensions: .dcx
Features: open
--------------------------------------------------------------------
DDS
Extensions: .dds
Features: open, save
--------------------------------------------------------------------
DIB image/bmp
Extensions: .dib
Features: open, save
--------------------------------------------------------------------
EPS application/postscript
Extensions: .eps, .ps
Features: open, save
--------------------------------------------------------------------
FITS
Extensions: .fit, .fits
Features: open, save
--------------------------------------------------------------------
FLI
Extensions: .flc, .fli
Features: open
--------------------------------------------------------------------
FTEX
Extensions: .ftc, .ftu
Features: open
--------------------------------------------------------------------
GBR
Extensions: .gbr
Features: open
--------------------------------------------------------------------
GIF image/gif
Extensions: .gif
Features: open, save, save_all
--------------------------------------------------------------------
GRIB
Extensions: .grib
Features: open, save
--------------------------------------------------------------------
HDF5
Extensions: .h5, .hdf
Features: open, save
--------------------------------------------------------------------
ICNS image/icns
Extensions: .icns
Features: open, save
--------------------------------------------------------------------
ICO image/x-icon
Extensions: .ico
Features: open, save
--------------------------------------------------------------------
IM
Extensions: .im
Features: open, save
--------------------------------------------------------------------
IMT
Features: open
--------------------------------------------------------------------
IPTC
Extensions: .iim
Features: open
--------------------------------------------------------------------
JPEG image/jpeg
Extensions: .jfif, .jpe, .jpeg, .jpg
Features: open, save
--------------------------------------------------------------------
JPEG2000 image/jp2
Extensions: .j2c, .j2k, .jp2, .jpc, .jpf, .jpx
Features: open, save
--------------------------------------------------------------------
MCIDAS
Features: open
--------------------------------------------------------------------
MPEG video/mpeg
Extensions: .mpeg, .mpg
Features: open
--------------------------------------------------------------------
MSP
Extensions: .msp
Features: open, save, decode
--------------------------------------------------------------------
PCD
Extensions: .pcd
Features: open
--------------------------------------------------------------------
PCX image/x-pcx
Extensions: .pcx
Features: open, save
--------------------------------------------------------------------
PIXAR
Extensions: .pxr
Features: open
--------------------------------------------------------------------
PNG image/png
Extensions: .apng, .png
Features: open, save, save_all
--------------------------------------------------------------------
PPM image/x-portable-anymap
Extensions: .pbm, .pgm, .pnm, .ppm
Features: open, save
--------------------------------------------------------------------
PSD image/vnd.adobe.photoshop
Extensions: .psd
Features: open
--------------------------------------------------------------------
SGI image/sgi
Extensions: .bw, .rgb, .rgba, .sgi
Features: open, save
--------------------------------------------------------------------
SPIDER
Features: open, save
--------------------------------------------------------------------
SUN
Extensions: .ras
Features: open
--------------------------------------------------------------------
TGA image/x-tga
Extensions: .icb, .tga, .vda, .vst
Features: open, save
--------------------------------------------------------------------
TIFF image/tiff
Extensions: .tif, .tiff
Features: open, save, save_all
--------------------------------------------------------------------
WEBP image/webp
Extensions: .webp
Features: open, save, save_all
--------------------------------------------------------------------
WMF
Extensions: .emf, .wmf
Features: open, save
--------------------------------------------------------------------
XBM image/xbm
Extensions: .xbm
Features: open, save
--------------------------------------------------------------------
XPM image/xpm
Extensions: .xpm
Features: open
--------------------------------------------------------------------
XVTHUMB
Features: open
---------