### PR TITLE
Dont error for missing image groups

### DIFF
--- a/.idea/runConfigurations/manifestBuilder_local.xml
+++ b/.idea/runConfigurations/manifestBuilder_local.xml
@@ -7,6 +7,7 @@
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="FRELM" value="Archive" />
+      <env name="AO_AWS_SNS_TOPIC_ARN" value="arn:aws:sns:us-east-1:170602929106:ArchiveOpsNotifications" />
     </envs>
     <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/../tmp/volume-manifest-builder" />
@@ -15,7 +16,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="manifestBuilder" />
-    <option name="PARAMETERS" value="-w /Volumes/home/prod/volume-manifest-builder-37/W28882 fs" />
+    <option name="PARAMETERS" value="-w $USER_HOME$/prod/ao620/W3CN15305 fs" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="true" />

--- a/.idea/runConfigurations/manifestFromS3_local.xml
+++ b/.idea/runConfigurations/manifestFromS3_local.xml
@@ -13,7 +13,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="manifestBuilder" />
-    <option name="PARAMETERS" value="-l . -d debug -w W8LS68211 fs -c ~/dev/tmp/Archive -i images" />
+    <option name="PARAMETERS" value="-l . -d debug -w W8LS68211 fs -c / -i images" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="true" />

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 console_scripts = ['manifestforwork = v_m_b.manifestBuilder:manifestShell',
                    'manifestFromS3 = v_m_b.manifestBuilder:manifestFromS3']
 
-setup(version='1.2.0',
+setup(version='1.2.1',
       name='bdrc-volume-manifest-builder',
       packages=find_packages(),
       url='https://github.com/buda-base/volume-manifest-builder/', license='', author='jimk',

--- a/v_m_b/manifestBuilder.py
+++ b/v_m_b/manifestBuilder.py
@@ -130,7 +130,7 @@ def doOneManifest(work_Rid: str) -> bool:
                 shell_logger.info(f"Volume {work_Rid}-{vi.imageGroupID} processing: {_et:05.3} sec ")
             else:
                 _et = time.monotonic() - _tick
-                shell_logger.error(f"No manifest created for {work_Rid}-{vi.imageGroupID} ")
+                shell_logger.info(f"No manifest created for {work_Rid}-{vi.imageGroupID} ")
 
         is_success = True
     except Exception as inst:


### PR DESCRIPTION
Fixes #55 
Partial resyncs are a normal use case. Change the warning level for this case. (If the build fails for some other reason, that will be an exception that another handler will handle.