### PR TITLE
BUDA is now primary source for image groups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 console_scripts = ['manifestforwork = v_m_b.manifestBuilder:manifestShell',
                    'manifestFromS3 = v_m_b.manifestBuilder:manifestFromS3']
 
-setup(version='1.2.6',
+setup(version='1.2.7',
       name='bdrc-volume-manifest-builder',
       packages=find_packages(),
       url='https://github.com/buda-base/volume-manifest-builder/', license='', author='jimk',

--- a/v_m_b/manifestCommons.py
+++ b/v_m_b/manifestCommons.py
@@ -17,7 +17,7 @@ from v_m_b.S3WorkFileManager import S3WorkFileManager
 S3_DEST_BUCKET: str = "archive.tbrc.org"
 
 # jimk Toggle legacy and new sources
-BUDA_IMAGE_GROUP = False
+BUDA_IMAGE_GROUP = True
 
 S3_MANIFEST_WORK_LIST_BUCKET: str = "manifest.bdrc.org"
 LOG_FILE_ROOT: str = "/var/log/VolumeManifestTool"
@@ -47,6 +47,7 @@ def getVolumeInfos(workRid: str, image_repo: ImageRepositoryBase) -> []:
     from v_m_b.VolumeInfo.VolumeInfoeXist import VolumeInfoeXist
 
     vol_infos: [] = []
+    # Try BUDA first, and only if that fails, try eXist
     if BUDA_IMAGE_GROUP:
         vol_infos = (VolumeInfoBUDA(image_repo)).fetch(workRid)
 


### PR DESCRIPTION
Change the resolving sequence for image groups for a work. It used to resolve to eXist only. 
With this change, v-m-b now resolves to BUDA first, and falls back to eXist if BUDA can't resolve the image group.
If neither has a catalog entry, it will still fail as it used to.

This is release 1.2.7 on pyPI.org. I've installed it on bodhi:service and sattva:service and my own id. 